### PR TITLE
Cap Documenter to v0.19

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,6 @@ before_install:
 after_success:
   - sudo pip install --upgrade pip
   - pip install --user mkdocs mkdocs-material
-  - julia -e 'using Pkg; Pkg.add("Documenter"); Pkg.add("Literate")'
+  - julia -e 'using Pkg; ps=PackageSpec(name="Documenter", version="0.19"); Pkg.add(ps); Pkg.pin(ps); Pkg.add("Literate")'
   - julia -e 'using Pkg; Pkg.add("MIDI"); Pkg.add("MotifSequenceGenerator"); Pkg.add("MusicManipulations")'
   - julia -e 'using Pkg, JuliaMusic_documentation; cd(joinpath(dirname(pathof(JuliaMusic_documentation)), "..")); include(joinpath("docs", "make.jl"))'


### PR DESCRIPTION
Due to upcoming breaking changes in Documenter. This makes sure that the doc builds do not start failing when 0.20 lands in METADATA. [See this thread on Discourse for more information.](https://discourse.julialang.org/t/psa-documenter-jl-breaking-changes-version-capping/16431) 

Ref: JuliaDocs/Documenter.jl#861